### PR TITLE
Feat/windows powershell

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -30,15 +30,17 @@ To install from the source code (not recommended):
 Import-Module /path/to/BinWips/src/Modules/BinWips
 ```
 
-Create a simple program from an inline script block to create a program with the default name `PSBinary.exe`:
+Create a simple program from an inline script block to create a program with the
+default name `PSBinary.exe`:
 
 ```powershell
 New-BinWips -ScriptBlock {echo "Hello World!"}
 
 # Run: ./PSBinary.exe
-# Output: 
+# Output:
 # Hello World!
 ```
+
 Interactive programs are supported:
 
 ```powershell
@@ -52,7 +54,11 @@ New-BinWips -ScriptBlock {
 # Hello BinWips!
 ```
 
-You can also generate programs from script files. The files will be loaded in the order they are passed in. The first filename will be used as the name of the generated program. For example, if you have two files `myScript.ps1` and `myOtherScript.ps1` and you want to generate a program called `myScript.exe` you would run:
+You can also generate programs from script files. The files will be loaded in
+the order they are passed in. The first filename will be used as the name of the
+generated program. For example, if you have two files `myScript.ps1` and
+`myOtherScript.ps1` and you want to generate a program called `myScript.exe` you
+would run:
 
 ```powershell
 New-BinWips -InFile "path/to/myScript.ps1", "path/to/myOtherScript.ps1"
@@ -60,7 +66,8 @@ New-BinWips -InFile "path/to/myScript.ps1", "path/to/myOtherScript.ps1"
 # Run: ./myScript.exe
 ```
 
-You can always override the name of the generated program with the `-OutFile` parameter.
+You can always override the name of the generated program with the `-OutFile`
+parameter.
 
 > :spiral_notepad: Note: By default BinWips compiles to the platform and
 > architecture of the machine it is run on. You can override this behavior with
@@ -82,7 +89,9 @@ New-BinWips -ScriptBlock {
 # Param was Hello World!
 ```
 
-When generating a program from a script file, the script file can take parameters as well, if you pass in multiple script files, the program parameters are generated from the first script file.
+When generating a program from a script file, the script file can take
+parameters as well, if you pass in multiple script files, the program parameters
+are generated from the first script file.
 
 Parameter validation works, tab completion does not. You can use
 `.\PSBinary.exe help` to get help. For your module. This will produce PowerShell
@@ -401,18 +410,32 @@ class template. The following tokens are replaced by default. Any tokens marked
 as required must be included in the class template or an exception will be
 thrown.
 
-| Token Name     | Required | Description                                         |
-| -------------- | -------- | --------------------------------------------------- |
-| BinWipsVersion | Yes      | The version of BinWips used to generate the program |
-| Script         | Yes      | The script to run, encoded as a base64 string       |
-| RuntimeSetup   | Yes      | The runtime setup script, encoded as a base64 string |
-| ClassName      | Yes      | The name of the class to generate                   |
-| Namespace      | Yes      | The namespace to use                                |
-| BinWipsVersion | No       | The version of BinWips used to generate the program |
-| FunctionName   | No       | The name of the function to display when showing help documentation |
+| Token Name      | Required | Description                                                                                 |
+| --------------- | -------- | ------------------------------------------------------------------------------------------- |
+| BinWipsVersion  | Yes      | The version of BinWips used to generate the program                                         |
+| Script          | Yes      | The script to run, encoded as a base64 string                                               |
+| RuntimeSetup    | Yes      | The runtime setup script, encoded as a base64 string                                        |
+| ClassName       | Yes      | The name of the class to generate                                                           |
+| Namespace       | Yes      | The namespace to use                                                                        |
+| BinWipsVersion  | No       | The version of BinWips used to generate the program                                         |
+| FunctionName    | No       | The name of the function to display when showing help documentation                         |
 | BinWipsPipeGuid | No       | The guid used to identify the pipe between the generated program and the powershell process |
 
-When creating a custom class template you can use any of the above tokens. You can also define additional tokens, enabling template reuse.
+When creating a custom class template you can use any of the above tokens. You
+can also define additional tokens, enabling template reuse.
+
+## References
+
+If you're C# class template needs to reference other assemblies you can use the
+`-HostReferences` parameter. This parameter takes an array of strings which are
+paths to assemblies to reference. For example, if you want to reference
+`Newtonsoft.Json.dll` you would use the following syntax:
+
+```powershell
+New-BinWips -InFile "MyScript.ps1" -HostReferences "C:\Path\To\Newtonsoft.Json.dll"
+```
+
+BinWips will throw an error if the assembly does not exist or if you do not have a matching reference for each assembly you reference in your class template.
 
 ## Testing
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -424,7 +424,7 @@ Testing is done through Pester. To run the tests, clone the repo and run
 Invoke-Pester -Script ./tests/BinWips.Tests.ps1
 
 <#
-Tags: Named Params, Switches
+Tags: Basic, MultiFile, Named Params, Switches, ScriptBlockParameters, ClassTemplate, CustomNamespace, CustomClassName, Resources
 #>
 ```
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -84,14 +84,6 @@ New-BinWips -ScriptBlock {
 
 When generating a program from a script file, the script file can take parameters as well, if you pass in multiple script files, the program parameters are generated from the first script file.
 
-```powershell
-
-Arguments work the same as they would if you wrote a script. E.g.
-
-```powershell
-.\PSBinary.exe -String1 "Some Text" -ScriptBlock "{Write-Host 'Inception'}" -Switch1 -Array "Arrays?","Of Course"
-```
-
 Parameter validation works, tab completion does not. You can use
 `.\PSBinary.exe help` to get help. For your module. This will produce PowerShell
 style help for your program. No additional work is required on your part, this

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -52,11 +52,17 @@ New-BinWips -ScriptBlock {
 # Hello BinWips!
 ```
 
-You can also generate programs from script files:
+You can also generate programs from script files. The files will be loaded in the order they are passed in. The first filename will be used as the name of the generated program. For example, if you have two files `myScript.ps1` and `myOtherScript.ps1` and you want to generate a program called `myScript.exe` you would run:
 
 ```powershell
-New-BinWips -InFile "path/to/myScript.ps1"
+New-BinWips -InFile "path/to/myScript.ps1", "path/to/myOtherScript.ps1"
+
+# Run: ./myScript.exe
 ```
+
+You can always override the name of the generated program with the `-OutFile` parameter.
+
+```powershell
 
 An executable will be generated in the current directory with the name
 `myScript.exe`.
@@ -70,18 +76,20 @@ BinWips programs can take parameters just like the PowerShell scripts they are
 based on.
 
 ```powershell
-# Note the escaped variable `$myParam
+# If we don't escape (`) the $ then PowerShell will may to expand it before passing it BinWips
 New-BinWips -ScriptBlock {
     param($myParam)
     echo "Param was `$myParam"
 }
 
-# Also works with scripts
-New-BinWips -InFile "MyScript.ps1"
-## Content of MyScript.ps1
-# param($myParam)
-# echo "Param was $myParam"
+# Run: ./PSBinary.exe -myParam "Hello World!"
+# Output:
+# Param was Hello World!
 ```
+
+When generating a program from a script file, the script file can take parameters as well, if you pass in multiple script files, the program parameters are generated from the first script file.
+
+```powershell
 
 Arguments work the same as they would if you wrote a script. E.g.
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -62,15 +62,10 @@ New-BinWips -InFile "path/to/myScript.ps1", "path/to/myOtherScript.ps1"
 
 You can always override the name of the generated program with the `-OutFile` parameter.
 
-```powershell
-An executable will be generated in the current directory with the name
-`myScript.exe`.
-
 > :spiral_notepad: Note: By default BinWips compiles to the platform and
 > architecture of the machine it is run on. You can override this behavior with
 > the `-Platform` and `-Architecture` parameters. See the
 > [Parameters](#Parameters) section for more information.
-
 
 BinWips programs can take parameters just like the PowerShell scripts they are
 based on.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -214,7 +214,7 @@ PARAMETERS
     
     -HostReferences <String[]>
         List of .NET assemblies for the host .exe to reference. These references will not be accessible from within the powershell script.
-        
+
     -Resources <String[]>
         List of files to include with the app
                     - If -NoEmbedResources is specified then files are embedded in the exe.
@@ -242,6 +242,18 @@ PARAMETERS
     -ExtraArguments <String[]>
         Additional parameters to pass to the bflat compiler
 
+    -PowerShellEdition <String>
+        Which edition of PowerShell to target:
+         - Core: PowerShell Core (pwsh)
+         - Desktop: Windows PowerShell (powershell.exe)
+
+        If not specified, defaults to the edition of PowerShell that is running the cmdlet.
+        So if this function is run from pwsh, it will default to PowerShell Core.
+        If this function is run from powershell.exe, it will default to Windows PowerShell.
+
+        PowerShellEdition='Desktop' is only supported on Windows PowerShell 5.1 and newer.
+        If you try to use  PowerShellEdition='Desktop' and Platform='Linux', an error will be thrown.
+    
     -WhatIf [<SwitchParameter>]
 
     -Confirm [<SwitchParameter>]

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -84,30 +84,19 @@ When generating a program from a script file, the script file can take
 parameters as well, if you pass in multiple script files, the program parameters
 are generated from the first script file.
 
-Parameter validation works, tab completion does not. You can use
-`.\PSBinary.exe help` to get help. For your module. This will produce PowerShell
-style help for your program. No additional work is required on your part, this
-is done automatically.
+Parameter validation works, tab completion does not. BinWips automatically adds
+support for getting help on the generated program by using `.\PSBinary.exe help`.
 
 ```text
 NAME
     PSBinary
 
 SYNTAX
-    PSBinary [-baz] [<CommonParameters>]
-
+    PSBinary [-SomeParam] <string> [<CommonParameters>]
 
 PARAMETERS
-    -baz
-
-    <CommonParameters>
-        This cmdlet supports the common parameters: Verbose, Debug,
-        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-        OutBuffer, PipelineVariable, and OutVariable. For more information, see
-        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
-
-REMARKS
-    None
+    -SomeParam <string>
+        Description for SomeParam
 ```
 
 ### Other examples

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -54,6 +54,19 @@ New-BinWips -ScriptBlock {
 # Hello BinWips!
 ```
 
+As well as, programs that take parameters:
+
+```powershell
+New-BinWips -ScriptBlock {
+    param($myParam)
+    echo "Param was $myParam"
+}
+
+# Run: ./PSBinary.exe -myParam "Hello World!"
+# Output:
+# Param was Hello World!
+```
+
 You can also generate programs from script files. The files will be loaded in
 the order they are passed in. The first filename will be used as the name of the
 generated program. For example, if you have two files `myScript.ps1` and
@@ -73,21 +86,6 @@ parameter.
 > architecture of the machine it is run on. You can override this behavior with
 > the `-Platform` and `-Architecture` parameters. See the
 > [Parameters](#Parameters) section for more information.
-
-BinWips programs can take parameters just like the PowerShell scripts they are
-based on.
-
-```powershell
-# If we don't escape (`) the $ then PowerShell will may to expand it before passing it BinWips
-New-BinWips -ScriptBlock {
-    param($myParam)
-    echo "Param was `$myParam"
-}
-
-# Run: ./PSBinary.exe -myParam "Hello World!"
-# Output:
-# Param was Hello World!
-```
 
 When generating a program from a script file, the script file can take
 parameters as well, if you pass in multiple script files, the program parameters

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -19,9 +19,9 @@ Install-Module BinWips -AllowPrerelease
 Import-Module BinWips
 ```
 
-> Note: BinWips uses the [bflat](https://github.com/bflattened/bflat) compiler
-> to generate the C# code. This is a dependency of the module and will be
-> downloaded (one time) automatically if not detected in the path.
+> Note: BinWips uses [bflat](https://github.com/bflattened/bflat). This is a
+> dependency of the module and will be downloaded (one time) automatically if
+> not detected in the path.
 
 Create a simple program from an inline script block to create a program with the
 default name `PSBinary.exe`:
@@ -85,7 +85,8 @@ parameters as well, if you pass in multiple script files, the program parameters
 are generated from the first script file.
 
 Parameter validation works, tab completion does not. BinWips automatically adds
-support for getting help on the generated program by using `.\PSBinary.exe help`.
+support for getting help on the generated program by using
+`.\PSBinary.exe help`.
 
 ```text
 NAME
@@ -415,7 +416,8 @@ paths to assemblies to reference. For example, if you want to reference
 New-BinWips -InFile "MyScript.ps1" -HostReferences "C:\Path\To\Newtonsoft.Json.dll"
 ```
 
-BinWips will throw an error if the assembly does not exist or if you do not have a matching reference for each assembly you reference in your class template.
+BinWips will throw an error if the assembly does not exist or if you do not have
+a matching reference for each assembly you reference in your class template.
 
 ## Testing
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -30,23 +30,26 @@ To install from the source code (not recommended):
 Import-Module /path/to/BinWips/src/Modules/BinWips
 ```
 
-Create a simple program from an inline script block:
+Create a simple program from an inline script block to create a program with the default name `PSBinary.exe`:
 
 ```powershell
 New-BinWips -ScriptBlock {echo "Hello World!"}
-```
 
-This will generate a program named `PSBinary.exe` in the current directory.
-Confirm everything worked by running:
+# Run: ./PSBinary.exe
+# Output: 
+# Hello World!
+```
+Interactive programs are supported:
 
 ```powershell
-.\PSBinary.exe
-```
+New-BinWips -ScriptBlock {
+    $name = Read-Host "What is your name?"
+    echo "Hello $name!"
+}
 
-You should see the following output:
-
-```text
-Hello World!
+# Output:
+# What is your name?: BinWips
+# Hello BinWips!
 ```
 
 You can also generate programs from script files:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -211,7 +211,10 @@ PARAMETERS
         Reserved Tokens
         ---------------
         {#Script#} The script content to compile
-
+    
+    -HostReferences <String[]>
+        List of .NET assemblies for the host .exe to reference. These references will not be accessible from within the powershell script.
+        
     -Resources <String[]>
         List of files to include with the app
                     - If -NoEmbedResources is specified then files are embedded in the exe.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -317,9 +317,7 @@ You can fully customize the generated output by replacing the class template and
 you can run additional preprocessing before the compiler is invoked. If the
 built in customization options don't meet your needs this section will guide you
 through full customization of the compiled output. This section requires
-knowledge of C#. Additionally, unless you include the default BinWips attribute
-in your attributes/class template you will not be able to detect your
-application as a BinWips application (how-to is included in this section).
+knowledge of C#.
 
 ### Class Tempalates
 
@@ -397,6 +395,26 @@ namespace {#Namespace#} {
     }
 }
 ```
+
+### Tokens
+
+BinWips uses tokens in the format of `{#TokenName#}` to replace values in the
+class template. The following tokens are replaced by default. Any tokens marked
+as required must be included in the class template or an exception will be
+thrown.
+
+| Token Name     | Required | Description                                         |
+| -------------- | -------- | --------------------------------------------------- |
+| BinWipsVersion | Yes      | The version of BinWips used to generate the program |
+| Script         | Yes      | The script to run, encoded as a base64 string       |
+| RuntimeSetup   | Yes      | The runtime setup script, encoded as a base64 string |
+| ClassName      | Yes      | The name of the class to generate                   |
+| Namespace      | Yes      | The namespace to use                                |
+| BinWipsVersion | No       | The version of BinWips used to generate the program |
+| FunctionName   | No       | The name of the function to display when showing help documentation |
+| BinWipsPipeGuid | No       | The guid used to identify the pipe between the generated program and the powershell process |
+
+When creating a custom class template you can use any of the above tokens. You can also define additional tokens, enabling template reuse.
 
 ## Testing
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -23,13 +23,6 @@ Import-Module BinWips
 > to generate the C# code. This is a dependency of the module and will be
 > downloaded (one time) automatically if not detected in the path.
 
-To install from the source code (not recommended):
-
-```powershell
-# git clone or download the source code from the releases page
-Import-Module /path/to/BinWips/src/Modules/BinWips
-```
-
 Create a simple program from an inline script block to create a program with the
 default name `PSBinary.exe`:
 
@@ -445,6 +438,15 @@ Invoke-Pester -Script ./tests/BinWips.Tests.ps1
 <#
 Tags: Basic, MultiFile, Named Params, Switches, ScriptBlockParameters, ClassTemplate, CustomNamespace, CustomClassName, Resources
 #>
+```
+
+## Installing from source
+
+To install from the source code (not recommended):
+
+```powershell
+git clone https://github.com/d-carrigg/BinWips.git
+Import-Module ./BinWips/src/Modules/BinWips
 ```
 
 ## Troubleshoting

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -63,7 +63,6 @@ New-BinWips -InFile "path/to/myScript.ps1", "path/to/myOtherScript.ps1"
 You can always override the name of the generated program with the `-OutFile` parameter.
 
 ```powershell
-
 An executable will be generated in the current directory with the name
 `myScript.exe`.
 
@@ -71,6 +70,7 @@ An executable will be generated in the current directory with the name
 > architecture of the machine it is run on. You can override this behavior with
 > the `-Platform` and `-Architecture` parameters. See the
 > [Parameters](#Parameters) section for more information.
+
 
 BinWips programs can take parameters just like the PowerShell scripts they are
 based on.

--- a/src/Modules/BinWips/BinWips.psd1
+++ b/src/Modules/BinWips/BinWips.psd1
@@ -12,7 +12,7 @@
 RootModule = 'BinWips.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.2'
+ModuleVersion = '0.0.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/Modules/BinWips/BinWips.psd1
+++ b/src/Modules/BinWips/BinWips.psd1
@@ -95,7 +95,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = @('Desktop','PSEdition_Core', 'Windows', 'Linux')
+        Tags = @('Desktop','PSEdition_Core', 'Windows', 'Linux', 'Compiler', 'Executable', 'Binary', 'Application')
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/d-carrigg/BinWips/blob/master/LICENSE.txt'

--- a/src/Modules/BinWips/BinWips.psd1
+++ b/src/Modules/BinWips/BinWips.psd1
@@ -33,7 +33,7 @@ Copyright = '(c) 2021 dcarrigg. All rights reserved.'
 Description = 'Binary Written in PowerShell. Convert PowerShell scripts into .NET Applications'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '6.0'
+PowerShellVersion = '5.0'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''
@@ -95,7 +95,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = @('Desktop','PSEdition_Core', 'Windows', 'Linux', 'Compiler', 'Executable', 'Binary', 'Application')
+        Tags = @('PSEdition_Desktop','PSEdition_Core', 'Windows', 'Linux', 'Compiler', 'Executable', 'Binary', 'Application')
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/d-carrigg/BinWips/blob/master/LICENSE.txt'

--- a/src/Modules/BinWips/Private/Build-BFlat.ps1
+++ b/src/Modules/BinWips/Private/Build-BFlat.ps1
@@ -123,6 +123,12 @@
       [switch]
       $Force, 
 
+      <#
+        List of .NET assemblies to reference. 
+      #>
+      [string[]]
+      $References,
+
       <# List of files to include with the app 
              - If -NoEmbedResources is specified then files are embedded in the exe.
                 - Files are copied to out dir with exe if they don't already exist
@@ -223,6 +229,15 @@
          {
             #https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/resource-compiler-option
             $cscArgs += "--resource"
+            $cscArgs += $r
+         }
+      }
+
+      if ($References)
+      {
+         foreach ($r in $References)
+         {
+            $cscArgs += "--reference"
             $cscArgs += $r
          }
       }

--- a/src/Modules/BinWips/Private/Build-BFlat.ps1
+++ b/src/Modules/BinWips/Private/Build-BFlat.ps1
@@ -248,12 +248,8 @@
 
  
       # 6. Run C# compiler over those files and produce an exe in the out dir
-      $cscArgs +=  "$(Resolve-Path "$ScratchDir/PSBinary.cs")"
-      $cscArgs +=  "$(Resolve-Path "$ScratchDir/BinWipsAttr.cs")"
-      # $cscArgs += @(
-      #    "$ScratchDir/PSBinary.cs", 
-      #    "$ScratchDir/BinWipsAttr.cs"
-      # )
+      $cscArgs +=  "$ScratchDir/PSBinary.cs"
+      $cscArgs +=  "$ScratchDir/BinWipsAttr.cs"
 
       $guid = [guid]::NewGuid().ToString()
       $Tokens['BinWipsPipeGuid'] = $guid

--- a/src/Modules/BinWips/Private/Build-BFlat.ps1
+++ b/src/Modules/BinWips/Private/Build-BFlat.ps1
@@ -235,21 +235,25 @@
 
       if ($References)
       {
+         $cscArgs += "--reference"
          foreach ($r in $References)
          {
-            $cscArgs += "--reference"
             $cscArgs += $r
          }
       }
      
+ 
+
       # 2. Read in script file if needed
 
  
       # 6. Run C# compiler over those files and produce an exe in the out dir
-      $cscArgs += @(
-         "$ScratchDir/PSBinary.cs", 
-         "$ScratchDir/BinWipsAttr.cs"
-      )
+      $cscArgs +=  "$(Resolve-Path "$ScratchDir/PSBinary.cs")"
+      $cscArgs +=  "$(Resolve-Path "$ScratchDir/BinWipsAttr.cs")"
+      # $cscArgs += @(
+      #    "$ScratchDir/PSBinary.cs", 
+      #    "$ScratchDir/BinWipsAttr.cs"
+      # )
 
       $guid = [guid]::NewGuid().ToString()
       $Tokens['BinWipsPipeGuid'] = $guid

--- a/src/Modules/BinWips/Private/Build-BFlat.ps1
+++ b/src/Modules/BinWips/Private/Build-BFlat.ps1
@@ -162,7 +162,21 @@
       $Architecture,
 
       [switch]
-      $Cleanup 
+      $Cleanup,
+
+        <#
+        Which edition of PowerShell to target (PowerShell Core vs Windows PowerShell). 
+        If not specified, defaults to the edition of PowerShell that is running the cmdlet.
+        So if this function is run from pwsh, it will default to PowerShell Core.
+        If this function is run from powershell.exe, it will default to Windows PowerShell.
+
+        PowerShellEdition='Desktop' is only supported on Windows PowerShell 5.1 and newer. 
+        If you try to use  PowerShellEdition='Desktop' and Platform='Linux', an error will be thrown. 
+      #>
+      [string]
+      [ValidateSet('Core', 'Desktop')]
+      $PowerShellEdition
+      
    )
 
    Begin
@@ -270,6 +284,7 @@
          CompilerPath       = $dotNetPath
          CompilerArgs       = $cscArgs
          ScratchDir         = $ScratchDir
+         PowerShellEdition  = $PowerShellEdition
       }
 
       Write-BinWipsExe @funcArgs

--- a/src/Modules/BinWips/Private/Write-BinWipsExe.ps1
+++ b/src/Modules/BinWips/Private/Write-BinWipsExe.ps1
@@ -250,7 +250,7 @@ function Write-BinWipsExe
          
          if ($results -like '*Error*')
          {
-           throw $results
+            Write-Output $results
          }
          elseif ($null -ne $results)
          {

--- a/src/Modules/BinWips/Private/Write-BinWipsExe.ps1
+++ b/src/Modules/BinWips/Private/Write-BinWipsExe.ps1
@@ -237,6 +237,8 @@ function Write-BinWipsExe
          $CompilerArgs | ForEach-Object {
             $psi.ArgumentList.Add($_)
          }
+ 
+ 
   
 
 

--- a/src/Modules/BinWips/Private/Write-BinWipsExe.ps1
+++ b/src/Modules/BinWips/Private/Write-BinWipsExe.ps1
@@ -49,6 +49,8 @@ function Write-BinWipsExe
       [string]
       $OutFile,
 
+      
+
       <# Hashtable of assembly attributes to apply to the assembly level.
              - list of defaults here: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/global
              - custom attributes can also be aplied.
@@ -157,11 +159,12 @@ function Write-BinWipsExe
       
       # 4. Insert script and replace tokens in class template
       $funtionName = [System.IO.Path]::GetFileNameWithoutExtension($OutFile)
+      $binWipsVersion = $MyInvocation.MyCommand.ScriptBlock.Module.Version
       $csProgram = $ClassTemplate | Set-BinWipsToken -Key Script -Value $encodedScript `
       | Set-BinWipsToken -Key RuntimeSetup -Value $encodedRuntimeSetup -Required `
       | Set-BinWipsToken -Key ClassName -Value $ClassName -Required `
       | Set-BinWipsToken -Key Namespace -Value $Namespace -Required `
-      | Set-BinWipsToken -Key BinWipsVersion -Value "0.1"
+      | Set-BinWipsToken -Key BinWipsVersion -Value $binWipsVersion
       | Set-BinWipsToken -Key FunctionName -Value $funtionName
    
    

--- a/src/Modules/BinWips/Public/New-BinWips.ps1
+++ b/src/Modules/BinWips/Public/New-BinWips.ps1
@@ -187,6 +187,12 @@ function New-BinWips
       [hashtable]
       $Tokens = @{},
 
+      <#
+        List of .NET assemblies to reference. 
+      #>
+      [string[]]
+      $References,
+
       <# List of files to include with the app 
              - If -NoEmbedResources is specified then files are embedded in the exe.
                 - Files are copied to out dir with exe if they don't already exist
@@ -366,6 +372,7 @@ function New-BinWips
          NoEmbedResources   = $NoEmbedResources
          Platform           = $Platform
          Architecture       = $Architecture
+         References = $References
       }     
 
       Build-Bflat @funcArgs

--- a/src/Modules/BinWips/Public/New-BinWips.ps1
+++ b/src/Modules/BinWips/Public/New-BinWips.ps1
@@ -188,10 +188,10 @@ function New-BinWips
       $Tokens = @{},
 
       <#
-        List of .NET assemblies to reference. 
+        List of .NET assemblies for the host .exe to reference. These references will not be accessible from within the powershell script.
       #>
       [string[]]
-      $References,
+      $HostReferences,
 
       <# List of files to include with the app 
              - If -NoEmbedResources is specified then files are embedded in the exe.
@@ -372,7 +372,7 @@ function New-BinWips
          NoEmbedResources   = $NoEmbedResources
          Platform           = $Platform
          Architecture       = $Architecture
-         References = $References
+         References         = $HostReferences
       }     
 
       Build-Bflat @funcArgs

--- a/src/Modules/BinWips/files/ClassTemplate.cs
+++ b/src/Modules/BinWips/files/ClassTemplate.cs
@@ -23,9 +23,9 @@ namespace {#Namespace#} {
             var runtimeSetup = DecodeBase64("{#RuntimeSetup#}");
             var funcName = "{#FunctionName#}";
             var ending = "";
-            if (args.Length == 1 && args[0] == "help")
+            if (AreArgsHelp(args))
             {
-                ending = $"Get-Help -Detailed {funcName}";
+                ending = $"Get-Help -Detailed {funcName}; Write-host 'Created with BinWips v{#BinWipsVersion#}'";
             }
             else
             {
@@ -44,7 +44,14 @@ namespace {#Namespace#} {
             var process = Process.Start(psi);
             process.WaitForExit();
         }
-        static string DecodeBase64(string encoded) 
+
+        static bool AreArgsHelp(string[] args)
+        {
+            if (args.Length != 1) return false;
+            string lower = args[0].ToLower();
+            return lower == "help" || lower == "-h" || lower == "--help";
+        }
+        static string DecodeBase64(string encoded)
             => System.Text.Encoding.Unicode.GetString(Convert.FromBase64String(encoded));
 
         static string EncodeBase64(string text)

--- a/src/Modules/BinWips/files/ClassTemplate.cs
+++ b/src/Modules/BinWips/files/ClassTemplate.cs
@@ -38,8 +38,9 @@ namespace {#Namespace#} {
             var encodedCommand = EncodeBase64(wrappedScript);
 
             // call PWSH to execute the script passing in the args
-            var psi = new ProcessStartInfo(@"pwsh");
-            psi.Arguments = "-NoProfile -NoLogo -EncodedCommand " + encodedCommand;
+            var psi = new ProcessStartInfo(@"{#PowerShellPath#}");
+            // e.g -NoProfile -NoLogo -EncodedCommand
+            psi.Arguments = "{#PowerShellArguments#}" + " " + encodedCommand;
 
             var process = Process.Start(psi);
             process.WaitForExit();

--- a/src/Modules/BinWips/files/ClassTemplate.cs
+++ b/src/Modules/BinWips/files/ClassTemplate.cs
@@ -40,27 +40,15 @@ namespace {#Namespace#} {
             // call PWSH to execute the script passing in the args
             var psi = new ProcessStartInfo(@"pwsh");
             psi.Arguments = "-NoProfile -NoLogo -EncodedCommand " + encodedCommand;
-            //psi.RedirectStandardInput = true;
+
             var process = Process.Start(psi);
-            process.EnableRaisingEvents = true;
-
             process.WaitForExit();
-
-
         }
-        static string DecodeBase64(string encoded)
-        {
-            var decodedBytes = Convert.FromBase64String(encoded);
-            var text = System.Text.Encoding.Unicode.GetString(decodedBytes);
-            return text;
-        }
+        static string DecodeBase64(string encoded) 
+            => System.Text.Encoding.Unicode.GetString(Convert.FromBase64String(encoded));
 
         static string EncodeBase64(string text)
-        {
-            var bytes = System.Text.Encoding.Unicode.GetBytes(text);
-            var encoded = Convert.ToBase64String(bytes);
-            return encoded;
-        }
+         => Convert.ToBase64String(System.Text.Encoding.Unicode.GetBytes(text));
 
         static void StartServer()
         {
@@ -87,7 +75,9 @@ namespace {#Namespace#} {
                                 writer.Flush();
                             }
                         }
-                    } catch(Exception ex){
+                    }
+                    catch (Exception ex)
+                    {
                         // invalid resource
                         writer.WriteLine("Invalid Resource");
                         writer.WriteLine(ex.Message);

--- a/tests/BinWips.Tests.ps1
+++ b/tests/BinWips.Tests.ps1
@@ -13,8 +13,8 @@ Describe 'New-BinWips' {
     
     AfterEach {
         # Cleanup
-        Remove-Item -Path $script:outFile -ErrorAction SilentlyContinue
-        Remove-Item $script:scratchDir -Recurse -ErrorAction SilentlyContinue
+        #Remove-Item -Path $script:outFile -ErrorAction SilentlyContinue
+        #Remove-Item $script:scratchDir -Recurse -ErrorAction SilentlyContinue
     }
 
 

--- a/tests/BinWips.Tests.ps1
+++ b/tests/BinWips.Tests.ps1
@@ -46,6 +46,19 @@ Describe 'New-BinWips' {
         $result | Should -Be "Shared-Function from MutliFile1.ps1"
     }
 
+    
+    It 'Given a PowerShellEdition, should use that edition' -Tag "PowerShellEdition" {
+        New-BinWips -ScriptBlock { Write-Host "Hello World" } -ScratchDir $script:scratchDir -OutFile $script:outFile -PowerShellEdition Desktop
+
+        # read the PSBinary.exe and make sure it contains "powershell.exe"
+        $script:outFile | Should -Exist
+        $contents = Get-Content "$script:scratchDir/PSBinary.cs" -Raw
+        $contents | Should -BeLike "*powershell.exe*"
+
+        $result = & $script:outFile
+        $result | Should -Be "Hello World"
+    }
+
     It 'Given a script block with parameters, should accept the valid parameters' {
         New-BinWips -ScriptBlock { param($foo) Write-Output "$foo" } -ScratchDir $script:scratchDir -OutFile $script:outFile
 
@@ -207,4 +220,5 @@ Describe 'New-BinWips' {
         $result = & $script:outFile
         $result | Should -Be "Ignore Script"
     }
+
 }

--- a/tests/BinWips.Tests.ps1
+++ b/tests/BinWips.Tests.ps1
@@ -13,8 +13,8 @@ Describe 'New-BinWips' {
     
     AfterEach {
         # Cleanup
-        #Remove-Item -Path $script:outFile -ErrorAction SilentlyContinue
-        #Remove-Item $script:scratchDir -Recurse -ErrorAction SilentlyContinue
+        Remove-Item -Path $script:outFile -ErrorAction SilentlyContinue
+        Remove-Item $script:scratchDir -Recurse -ErrorAction SilentlyContinue
     }
 
 
@@ -200,7 +200,7 @@ Describe 'New-BinWips' {
         
         New-BinWips -ScriptBlock $sb -ScratchDir $script:scratchDir -OutFile $script:outFile `
              -ClassTemplate $classTemplate `
-             -HostReferences @($newtonsoftPath) -Verbose
+             -HostReferences @($newtonsoftPath)
         
         # So Long as the program compiles and runs, we're golden
         $script:outFile | Should -Exist


### PR DESCRIPTION
Adds support for having the exe run Windows PowerShell to BinWips. 

Use `-PowerShellEdition` Desktop to target Windows PowerShell. Updated module manifest to indicate support.

Defaults to `Core` when Linux is targeted, can be overridden by specifying `-PowerShellEdition`