### PR TITLE
Release/0.0.6 alpha

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,24 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Verify Module isn't bloated and doesn't contain bflat compiler
+        shell: pwsh
+        run: |
+          # We need to make sure we don't accidentally publish the bflat compiler (it's yuuuuuuuuge)
+          if([System.IO.Directory]::Exists("./src/Modules/BinWips/files/bflat")) {
+            Remove-Item -Path "./src/Modules/BinWips/files/bflat" -Recurse -Force
+          }
+          # Sanity check, make sure that we are less than 2MB in size
+          # just picked a reasonable number, change later as needed
+          $size = Get-ChildItem -Path ./src/Modules/BinWips -Recurse | Measure-Object -Property Length -Sum | Select-Object -ExpandProperty Sum
+          if($size -gt 2000000) {
+            throw "Module is too large ($size bytes), pipeline will need to be updated to publish this module"
+          }
+      - name: Check if Publish would work to PowerShell Gallery
+        shell: pwsh
+        run: |
+          # If This fails, it could mean we forgot to bump the version num in module manifest, DO NOT REMOVE
+          Publish-Module -Path ./src/Modules/BinWips -NuGetApiKey ${{ secrets.PSGALLERY_API_KEY }}  -WhatIf -Verbose -ErrorAction Stop
       - name: Publish PowerShell Module to github packages
         uses: natescherer/publish-powershell-action@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,5 +101,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           target: packages
           path: src/Modules/BinWips
+      - name: Publish PowerShell Module to PowerShell Gallery
+        uses: natescherer/publish-powershell-action@v1
+        with:
+          token: ${{ secrets.PSGALLERY_API_KEY }}
+          target: gallery
+          path: src/Modules/BinWips
 # See: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-powershell
 # https://github.com/marketplace/actions/publish-powershell

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -202,18 +202,18 @@ prevent accidental deletion of files.
 
 ### Namespace `String`
 
-Namespace for the generated program. This parameter is trumped by
-[Tokens](#tokens-hashtable), so placing a value here will be overriden by
+Namespace for the generated program. This parameter trumps the value in
+[Tokens](#tokens-hashtable), so placing a value here will override
 whatever is in [Tokens](#tokens-hashtable). So if you use
-`-Namespace A -Tokens @{Namespace='B'}` Namespace would be set to B not A Must
+`-Namespace A -Tokens @{Namespace='B'}` Namespace would be set to A not B Must
 be a valid C# namespace Defaults to `PSBinary`.
 
 ### ClassName `Object`
 
-Class name for the generated program This parameter is trumped by
-[Tokens](#tokens-hashtable), so placing a value here will be overriden by
-whatever is in [Tokens](#tokens-hashtable). So if you did
-`-ClassName A -Tokens @{ClassName='B'}` ClassName would be set to B not A must
+Class name for the generated program This parameter trumps the value in
+[Tokens](#tokens-hashtable), so placing a value here will override whatever is
+in [Tokens](#tokens-hashtable). So if you did
+`-ClassName A -Tokens @{ClassName='B'}` ClassName would be set to A not B. Must
 be a valid c# class name and cannot be equal to `Namespace`. Defaults to
 `Program`.
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -148,191 +148,185 @@ the help. You can also check out the
 [/tests/BinWips.Tests.ps1](/tests/BinWips.Tests.ps1) file for examples of how to
 use the module.
 
-```text
-SYNTAX
-    New-BinWips [-ScriptBlock] <Object> [-OutDir <String>] [-ScratchDir <String>] [-OutFile <String>] [-Cleanup] [-Namespace <String>] [-ClassName <Object>] [-AssemblyAttributes <String[]>] [-ClassAttributes <String[]>] [-ClassTemplate <String>]
-    [-AttributesTemplate <String>] [-Tokens <Hashtable>] [-Resources <String[]>] [-NoEmbedResources] [-Platform <String>] [-Architecture <String>] [-ExtraArguments <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+### Syntax
 
-    New-BinWips [-InFile] <String[]> [-OutDir <String>] [-ScratchDir <String>] [-OutFile <String>] [-Cleanup] [-Namespace <String>] [-ClassName <Object>] [-AssemblyAttributes <String[]>] [-ClassAttributes <String[]>] [-ClassTemplate <String>]
-    [-AttributesTemplate <String>] [-Tokens <Hashtable>] [-Resources <String[]>] [-NoEmbedResources] [-Platform <String>] [-Architecture <String>] [-ExtraArguments <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
-PARAMETERS
-    -ScriptBlock <Object>
-        The powershell command to convert into a program
-        cannot be combined with `InFile`
-
-    -InFile <String[]>
-        Source Script file(s), order is important
-        Files added in order entered
-        Exe name is defaulted to last file in array
-
-    -OutDir <String>
-        Directory to place output in, defaults to current directory
-        Dir will be created if it doesn't already exist.
-
-    -ScratchDir <String>
-        Change the directory where work will be done defaults to 'obj' folder in current directory
-        Use -Clean to clean this directory before building
-        Dir will be created if it doesn't already exist.
-
-    -OutFile <String>
-        Name of the .exe to generate. Defaults to the -InFile (replaced with .exe) or
-        PSBinary.exe if a script block is inlined
-
-    -Cleanup [<SwitchParameter>]
-        Clean the scratch directory before building
-        As compared to -KeepScratchDir which removes scratch dir *after* build.
-
-    -Namespace <String>
-        Namespace for the generated program.
-        This parameter is trumped by -Tokens, so placing a value here will be overriden by
-        whatever is in -Tokens
-        So if you did -Namespace A -Tokens @{Namespace='B'} Namespace would be set to B not A
-        Must be a valid C# namespace
-        Defaults to PSBinary
-
-    -ClassName <Object>
-        Class name for the generated program
-        This parameter is trumped by -Tokens, so placing a value here will be overriden
-        by whatever is in -Tokens
-        So if you did -ClassName A -Tokens @{ClassName='B'} ClassName would be set to B not A
-        must be a valid c# class name and cannot be equal to -Namespace
-        Defaults to Program
-
-    -AssemblyAttributes <String[]>
-        List of assembly attributes to apply to the assembly level.
-                    - list of defaults here: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/global
-                    - custom attributes can also be aplied.
-                    - Invalid attributes will throw a c# compiler exception
-
-    -ClassAttributes <String[]>
-        List of assembly attributes to apply to the class.
-                    - Any valid c# class attribute can be applied
-                    - Invalid attributes will throw a c# compiler exception
-
-    -ClassTemplate <String>
-        Override the default class template.
-        - BinWips Tokens (a character sequence such as beginning with {# and ending with #}) can be included
-          and will be replaced with the matching token either from defaults or the -Tokens paramter.
-        - If a BinWips exists with out a matching value in -Tokens an exception is thrown.
-        - Example: In the default template there is namespace '{#PSNameSpace#} {...}' when compiled
-          {#PSNamespace#} is replaced with PSBinary to produce namesapce PSBinary {...}
-
-    -AttributesTemplate <String>
-        Override the default attributes template.
-        BinWips Tokens not supported.
-
-    -Tokens <Hashtable>
-        Hashtable of tokens to replace in the class template.
-        Exclude the '{#' and '#}' in the keys.
-
-        Example:
-        -Tokens @{Namespace='CustomNamespace';ClassName='MyCoolClass'}
-
-        Reserved Tokens
-        ---------------
-        {#Script#} The script content to compile
-
-    -HostReferences <String[]>
-        List of .NET assemblies for the host .exe to reference. These references will not be accessible from within the powershell script.
-
-    -Resources <String[]>
-        List of files to include with the app
-                    - If -NoEmbedResources is specified then files are embedded in the exe.
-                       - Files are copied to out dir with exe if they don't already exist
-                    - Else files must be referenced specially (see below)
-
-                  To call files in script (if -NoEmbedresources is *not* included):
-                  `$myFile = Get-PsBinaryResource FileName.ext`
-                  where `FileName.ext` is the file you want to use.
-                  This returns the content of the file, not a path to it.
-
-                  Only use this if you want to package things like settings files
-                  or images. Otherwise files are accessed normally by the generated exe.
-
-    -NoEmbedResources [<SwitchParameter>]
-        Don't embed any resource specifed by -Resources
-        instead they are copied to out dir if they don't already exist
-
-    -Platform <String>
-        The platform to target
-
-    -Architecture <String>
-        The architecture to target
-
-    -ExtraArguments <String[]>
-        Additional parameters to pass to the bflat compiler
-
-    -PowerShellEdition <String>
-        Which edition of PowerShell to target:
-         - Core: PowerShell Core (pwsh)
-         - Desktop: Windows PowerShell (powershell.exe)
-
-        If not specified, defaults to the edition of PowerShell that is running the cmdlet.
-        So if this function is run from pwsh, it will default to PowerShell Core.
-        If this function is run from powershell.exe, it will default to Windows PowerShell.
-
-        PowerShellEdition='Desktop' is only supported on Windows PowerShell 5.1 and newer.
-        If you try to use  PowerShellEdition='Desktop' and Platform='Linux', an error will be thrown.
-
-    -WhatIf [<SwitchParameter>]
-
-    -Confirm [<SwitchParameter>]
-
-    <CommonParameters>
-        This cmdlet supports the common parameters: Verbose, Debug,
-        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-        OutBuffer, PipelineVariable, and OutVariable. For more information, see
-        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
-```
-
-## Embedding Resources
-
-If you want to package additional files with your application you can uses the
-`-Resources` parameter. A resource can be any file (images, other `exe`s,
-`dll`s, etc) and are embedded in the generated .exe by default. In other words,
-the module will still generate a single file regardless of the number of
-resources you include.
-
-To include additional files, pass an array of file paths to the `-Resources`
-parameter. For example, if you want to include 3 files:
-
-1. MyImage.png - located in the same directory as the script
-2. MyText.txt - located at c:\foo\MyText.txt
-3. MyRequiredLibrary.dll - located at
-   c:\Windows\ImportantFolder\MyRequiredLibrary.dll
-
-you would use the following syntax:
+There are two major ways to use the module. You can either pass in a script
+block or 1 or more scripts. The syntax for each is below.
 
 ```powershell
-New-BinWips -File MyScript.ps1 -Resources @(
-    '.\MyImage.png',
-    'c:\foo\MyText.txt',
-    'c:\Windows\ImportantFolder\MyRequiredLibrary.dll'
-)
+# Scriptblocks
+New-BinWips [-ScriptBlock] <Object> [-OutDir <String>] [-ScratchDir <String>] [-OutFile <String>]
+[-Cleanup] [-Namespace <String>] [-ClassName <Object>] [-AssemblyAttributes <String[]>]
+[-ClassAttributes <String[]>] [-ClassTemplate <String>] [-AttributesTemplate <String>]
+[-Tokens <Hashtable>] [-Resources <String[]>] [-NoEmbedResources] [-Platform <String>]
+ [-Architecture <String>] [-ExtraArguments <String[]>] [-WhatIf] [-Confirm]
+
+# With Scripts
+New-BinWips [-InFile] <String[]> [-OutDir <String>] [-ScratchDir <String>] [-OutFile <String>]
+[-Cleanup] [-Namespace <String>] [-ClassName <Object>] [-AssemblyAttributes <String[]>]
+[-ClassAttributes <String[]>] [-ClassTemplate <String>] [-AttributesTemplate <String>]
+[-Tokens <Hashtable>] [-Resources <String[]>] [-NoEmbedResources] [-Platform <String>]
+ [-Architecture <String>] [-ExtraArguments <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-The files must both exist and you must have access to said files otherwise
-BinWips will throw a terminating error. All files will be read in and embedded
-to the `.exe`. To use the resources in your script use the following syntax:
+### Script Block `Object`
 
-```powershell
-$myImageContent = Get-PSBinaryResource "MyImage.png"
-$myTextContent = Get-PSBinaryResource "MyText.txt"
-$myDll = Get-PSBinaryResource "MyRequiredLibrary.dll"
-```
+The powershell command to convert into a program cannot be combined with
+`InFile`.
 
-A few important notes:
+### InFile `String[]`
 
-- The file names are case sensitive and do not include the path (filename only).
-- You can’t use `Get-Content` or `Get-Item` cmdlets with these files because
-  they do not exist as files when deployed
+Source Script file(s), order is important Files added in order entered Exe name
+is defaulted to last file in array
 
-If you want to deploy the resources next to the `exe` instead of embedding them,
-include the `-NoEmbedResources` option. In which case the files will be copied
-to the `-OutDir` if they do not already exist at that location. If all resources
-are in the same directory as the script, or they already exist on the machine
-you want to deploy to. You don’t need to include them as resources, you can just
-access them as you normally would in your PowerShell script.
+### OutDir `String`
+
+Directory to place output in, defaults to current directory Dir will be created
+if it doesn't already exist.
+
+### ScratchDir `String`
+
+Change the directory where work will be done defaults to `.binwips` folder in
+current directory Use `-Cleanup` to clean this directory after build. Disabled
+by default to prevent accidental deletion of files.
+
+### OutFile `String`
+
+Name of the .exe to generate. Defaults to the -InFile (replaced with .exe) or
+PSBinary.exe if a script block is inlined
+
+### Cleanup `[<SwitchParameter>]`
+
+Recursively delete the scratch directory after build. Disabled by default to
+prevent accidental deletion of files.
+
+### Namespace `String`
+
+Namespace for the generated program. This parameter is trumped by
+[Tokens](#tokens-hashtable), so placing a value here will be overriden by
+whatever is in [Tokens](#tokens-hashtable). So if you use
+`-Namespace A -Tokens @{Namespace='B'}` Namespace would be set to B not A Must
+be a valid C# namespace Defaults to `PSBinary`.
+
+### ClassName `Object`
+
+Class name for the generated program This parameter is trumped by
+[Tokens](#tokens-hashtable), so placing a value here will be overriden by
+whatever is in [Tokens](#tokens-hashtable). So if you did
+`-ClassName A -Tokens @{ClassName='B'}` ClassName would be set to B not A must
+be a valid c# class name and cannot be equal to `Namespace`. Defaults to
+`Program`.
+
+### AssemblyAttributes `String[]`
+
+List of assembly attributes to apply to the assembly level. List of defaults can
+be found in the [Microsoft Language Reference](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/global).
+Custom attributes can also be aplied. Invalid attributes will throw a c#
+compiler exception.
+
+### ClassAttributes `String[]`
+
+List of assembly attributes to apply to the class. - Any valid c# class
+attribute can be applied - Invalid attributes will throw a c# compiler exception
+
+### ClassTemplate `String`
+
+Override the default class template. - BinWips Tokens (a character sequence such
+as beginning with {# and ending with #}) can be included and will be replaced
+with the matching token either from defaults or the -Tokens paramter. - If a
+BinWips exists with out a matching value in -Tokens an exception is thrown. -
+Example: In the default template there is namespace '{#PSNameSpace#} {...}' when
+compiled {#PSNamespace#} is replaced with PSBinary to produce namesapce PSBinary
+{...}. See the [Advanced Usage](#advanced-usage) section for more information.
+
+### AttributesTemplate `String`
+
+Override the default attributes template. BinWips Tokens not supported.
+
+### Tokens `Hashtable`
+
+Hashtable of tokens to replace in the class template. Exclude the '{#' and '#}'
+in the keys.
+
+Example: `-Tokens @{Namespace='CustomNamespace';ClassName='MyCoolClass'}`
+
+See the [Advanced Usage](#advanced-usage) section for more information.
+
+### HostReferences `String[]`
+
+List of .NET assemblies for the host .exe to reference. These references will
+not be accessible from within the powershell script.
+
+### Resources `String[]`
+
+List of files to include with the app. By default, embedded into the exe
+referenced by calling `Get-BinWipsResource FileName.ext` where `FileName.ext` is
+the file you want to use. This returns the content of the file, not a path to
+it. You can use the [NoEmbedResources](#noembedresources-switchparameter)
+parameter to copy the files to the `-OutDir` instead of embedding them.
+
+### NoEmbedResources `[<SwitchParameter>]`
+
+Don't embed any resource specifed by -Resources instead they are copied to out
+dir if they don't already exist. Useful in pipeline/CI scenarios where you want
+to ensure resources are available but don't want to embed them in the exe.
+
+### Platform `String`
+
+The platform to target. Valid values are:
+
+- `Windows`
+- `Linux`
+
+MacOS is not supported at this time. If not specified, defaults to the platform
+of the machine running the cmdlet.
+
+### Architecture `String`
+
+The architecture to target. Valid values are:
+
+- `x86`
+- `x64`
+- `arm64`
+
+If not specified, defaults to the architecture of the machine running the
+cmdlet.
+
+### ExtraArguments `String[]`
+
+Additional parameters to pass to the bflat compiler. See
+[Bflat Compiler](https://github.com/bflattened/bflat) for more information. Not
+commonly used.
+
+### PowerShellEdition
+
+Which edition of PowerShell to target:
+
+- `Core`: PowerShell Core (pwsh)
+- `Desktop`: Windows PowerShell (powershell.exe)
+
+If not specified, defaults to the edition of PowerShell that is running the
+cmdlet. So if this function is run from pwsh, it will default to PowerShell
+Core. If this function is run from powershell.exe, it will default to Windows
+PowerShell _unless_ you have specified `-Platform Linux`: in which case it will
+default to PowerShell Core. This is because PowerShell Core is the only edition
+of PowerShell that runs on Linux.
+
+PowerShellEdition='Desktop' is only supported on Windows PowerShell 5.1 and
+newer. If you try to use PowerShellEdition='Desktop' and Platform='Linux', an
+error will be thrown.
+
+### WhatIf `[<SwitchParameter>]`
+
+Support use of the PowerShell `-WhatIf` parameter. If used, the script will
+display which actions would be taken if the program were to compile. Verifies
+access to resources, but does not actually compile the program.
+
+### Confirm `[<SwitchParameter>]`
+
+Support use of the PowerShell `-Confirm` parameter. If used, the script will
+prompt the user to confirm the action before compiling the program. Similar to
+what if, but allows you to step through the compilation process.
 
 ## Advanced Usage
 
@@ -419,7 +413,7 @@ namespace {#Namespace#} {
 }
 ```
 
-### Tokens
+### Token Details
 
 BinWips uses tokens in the format of `{#TokenName#}` to replace values in the
 class template. The following tokens are replaced by default. Any tokens marked

--- a/src/Modules/BinWips/BinWips.psd1
+++ b/src/Modules/BinWips/BinWips.psd1
@@ -12,7 +12,7 @@
 RootModule = 'BinWips.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.5'
+ModuleVersion = '0.0.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/Modules/BinWips/BinWips.psd1
+++ b/src/Modules/BinWips/BinWips.psd1
@@ -30,7 +30,22 @@ CompanyName = 'dcarrigg'
 Copyright = '(c) 2021 dcarrigg. All rights reserved.'
 
 # Description of the functionality provided by this module
-Description = 'Binary Written in PowerShell. Convert PowerShell scripts into .NET Applications/executables.'
+Description = @"
+Binary Written in PowerShell. Convert PowerShell scripts into .NET Applications/executables.
+See the [Read Me](https://github.com/d-carrigg/BinWips) for full usage and examples.
+
+
+### Quickstart 
+
+```powershell
+Install-Module -Name BinWips -AllowPrerelease
+New-BinWips -ScriptBlock { Write-Host "Hello, World!" } -OutFile .\HelloWorld.exe
+.\HelloWorld.exe
+# Hello, World!
+```
+
+
+"@
 
 # Minimum version of the PowerShell engine required by this module
 PowerShellVersion = '5.0'

--- a/src/Modules/BinWips/BinWips.psd1
+++ b/src/Modules/BinWips/BinWips.psd1
@@ -32,19 +32,9 @@ Copyright = '(c) 2021 dcarrigg. All rights reserved.'
 # Description of the functionality provided by this module
 Description = @"
 Binary Written in PowerShell. Convert PowerShell scripts into .NET Applications/executables.
-See the [Read Me](https://github.com/d-carrigg/BinWips) for full usage and examples.
+Generates small, self-contained executables targeting Windows/Linux on x86/x64/ARM64.
 
-
-### Quickstart 
-
-```powershell
-Install-Module -Name BinWips -AllowPrerelease
-New-BinWips -ScriptBlock { Write-Host "Hello, World!" } -OutFile .\HelloWorld.exe
-.\HelloWorld.exe
-# Hello, World!
-```
-
-
+See https://github.com/d-carrigg/BinWips for more information.
 "@
 
 # Minimum version of the PowerShell engine required by this module

--- a/src/Modules/BinWips/Private/Build-BFlat.ps1
+++ b/src/Modules/BinWips/Private/Build-BFlat.ps1
@@ -164,7 +164,7 @@
       [switch]
       $Cleanup,
 
-        <#
+      <#
         Which edition of PowerShell to target (PowerShell Core vs Windows PowerShell). 
         If not specified, defaults to the edition of PowerShell that is running the cmdlet.
         So if this function is run from pwsh, it will default to PowerShell Core.
@@ -184,7 +184,7 @@
    }
    Process
    {
-      $dotNetPath = (get-command bflat -ErrorAction SilentlyContinue).Source
+      $dotNetPath = (Get-Command bflat -ErrorAction SilentlyContinue).Source
 
       # Locate the compiler
       $moduleRoot = Split-Path -Path $PSScriptRoot -Parent
@@ -201,7 +201,8 @@
          $dotNetPath = "$moduleRoot/files/bflat/linux-glibc/bflat"
       }
 
-      if(!(Test-Path $dotNetPath)){
+      if (!(Test-Path $dotNetPath))
+      {
          throw "Could not find bflat at $dotNetPath"
       }
     
@@ -210,8 +211,8 @@
          "--target", "$target",
          "--no-debug-info", # Don't create a .pdb
          "--os", "$($Platform.ToLower())",
-         "--arch", "$($Architecture.ToLower())",
-         "-i", "Main"
+         "--arch", "$($Architecture.ToLower())"
+         #"-i", "Main"
       )
       if ($null -ne $CscArgumentList -and $CscArgumentList.Length -gt 0)
       {
@@ -252,8 +253,8 @@
       }
      
       # Run C# compiler over those files and produce an exe in the out dir
-      $cscArgs +=  "$ScratchDir/PSBinary.cs"
-      $cscArgs +=  "$ScratchDir/BinWipsAttr.cs"
+      $cscArgs += "$ScratchDir/PSBinary.cs"
+      $cscArgs += "$ScratchDir/BinWipsAttr.cs"
 
       $guid = [guid]::NewGuid().ToString()
       $Tokens['BinWipsPipeGuid'] = $guid

--- a/src/Modules/BinWips/Private/Write-BinWipsExe.ps1
+++ b/src/Modules/BinWips/Private/Write-BinWipsExe.ps1
@@ -227,8 +227,11 @@ function Write-BinWipsExe
       {
          $csProgram = $csProgram | Remove-BinWipsToken -Key ClassAttributes
       }
+
+
       if ($Tokens)
       {
+         Write-Verbose "Applying $($Tokens.Count) tokens"
          $Tokens.GetEnumerator() | ForEach-Object {
             $csProgram = $csProgram | Set-BinWipsToken -Key $_.Key -Value $_.Value 
          } 

--- a/src/Modules/BinWips/Public/New-BinWips.ps1
+++ b/src/Modules/BinWips/Public/New-BinWips.ps1
@@ -118,7 +118,7 @@ function New-BinWips
       [string]
       $OutDir,
 
-      # Change the directory where work will be done defaults to 'obj' folder in current directory
+      # Change the directory where work will be done defaults to `.binwips` folder in current directory
       # Use -Cleanup to clean this directory after build
       # Dir will be created if it doesn't already exist. 
       [string]
@@ -317,6 +317,18 @@ function New-BinWips
       if ($PowerShellEdition -eq 'Desktop' -and $Platform -eq 'Linux')
       {
          throw "PowerShellEdition='Desktop' is only supported when Platform='Windows'"
+      }
+
+      # Warn if both -Namespace and -Tokens are specified and tokens contains Namespace
+      if ($PSBoundParameters.ContainsKey('Namespace') -and $null -ne $Tokens -and $Tokens.ContainsKey('Namespace'))
+      {
+         Write-Warning "Both -Namespace was specified and -Tokens, containing a value for Namespace. The value passed via -Namespace will be ignored."
+      }
+
+      # Warn if both -ClassName and -Tokens are specified and tokens contains ClassName
+      if ($PSBoundParameters.ContainsKey('ClassName') -and $null -ne $Tokens -and $Tokens.ContainsKey('ClassName'))
+      {
+         Write-Warning "Both -ClassName was specified and -Tokens, containing a value for ClassName. The value passed via -ClassName will be ignored."
       }
       
       $currentDir = (Get-Location).Path

--- a/src/Modules/BinWips/Public/New-BinWips.ps1
+++ b/src/Modules/BinWips/Public/New-BinWips.ps1
@@ -119,7 +119,7 @@ function New-BinWips
       $OutDir,
 
       # Change the directory where work will be done defaults to 'obj' folder in current directory
-      # Use -Clean to clean this directory before building
+      # Use -Cleanup to clean this directory after build
       # Dir will be created if it doesn't already exist. 
       [string]
       $ScratchDir,
@@ -130,8 +130,8 @@ function New-BinWips
       $OutFile,
 
 
-      # Clean the scratch directory before building
-      # As compared to -KeepScratchDir which removes scratch dir *after* build. 
+      # Recursively delete the scratch directory after build
+      # Disabled by default to prevent accidental deletion of files
       [switch]
       $Cleanup,
 
@@ -223,9 +223,6 @@ function New-BinWips
       $HostReferences,
 
       <# List of files to include with the app. I.e., `-Resources "MyFirstResource.txt", "MySecondResource.txt"`
-            - If -NoEmbedResources is specified then files are embedded in the exe.
-               - Files are copied to out dir with exe if they don't already exist
-            - Else files must be referenced specially (see below)
 
            To call files in script (if -NoEmbedresources is *not* included):
            `$myFile = Get-PsBinaryResource FileName.ext`

--- a/src/Modules/BinWips/Public/New-BinWips.ps1
+++ b/src/Modules/BinWips/Public/New-BinWips.ps1
@@ -8,6 +8,10 @@ function New-BinWips
        Generates a .EXE from a script. Support for parameters, interactive programs,
        cross-platform compiling, resource embedding. See examples for more information.
        Use Get-Help BinWips -Online to open the read me on github. 
+    .NOTES
+      This module is not associated with Bflat or the developers. The license for 
+      Bflat (if installed through the module), can be found at:
+         module_folder/BinWips/files/bflat/platform/License.txt 
     .EXAMPLE
        New-BinWips -ScriptBlock {Write-Host "Hello, World!"}
        # ./PSBinary.exe 

--- a/src/Modules/BinWips/Public/New-BinWips.ps1
+++ b/src/Modules/BinWips/Public/New-BinWips.ps1
@@ -136,18 +136,16 @@ function New-BinWips
       $Cleanup,
 
       # Namespace for the generated program. 
-      # This parameter is trumped by -Tokens, so placing a value here will be overriden by
-      # whatever is in -Tokens
-      # So if you did -Namespace A -Tokens @{Namespace='B'} Namespace would be set to B not A
+      # This parameter is trumps -Tokens, so placing a value here will be override whatever is in -Tokens
+      # So if you did -Namespace A -Tokens @{Namespace='B'} Namespace would be set to A not B
       # Must be a valid C# namespace
       # Defaults to PSBinary
       [string]
       $Namespace = "PSBinary",
 
       # Class name for the generated program
-      # This parameter is trumped by -Tokens, so placing a value here will be overriden
-      # by whatever is in -Tokens
-      # So if you did -ClassName A -Tokens @{ClassName='B'} ClassName would be set to B not A
+      # This parameter is trumps -Tokens, so placing a value here will override whatever is in -Tokens
+      # So if you did -ClassName A -Tokens @{ClassName='B'} ClassName would be set to A not B
       # must be a valid c# class name and cannot be equal to -Namespace
       # Defaults to Program
       $ClassName = "Program",
@@ -322,13 +320,18 @@ function New-BinWips
       # Warn if both -Namespace and -Tokens are specified and tokens contains Namespace
       if ($PSBoundParameters.ContainsKey('Namespace') -and $null -ne $Tokens -and $Tokens.ContainsKey('Namespace'))
       {
-         Write-Warning "Both -Namespace was specified and -Tokens, containing a value for Namespace. The value passed via -Namespace will be ignored."
+         Write-Warning "Both -Namespace was specified and -Tokens, containing a value for Namespace. The value passed via -Tokens will be ignored."
       }
 
       # Warn if both -ClassName and -Tokens are specified and tokens contains ClassName
       if ($PSBoundParameters.ContainsKey('ClassName') -and $null -ne $Tokens -and $Tokens.ContainsKey('ClassName'))
       {
-         Write-Warning "Both -ClassName was specified and -Tokens, containing a value for ClassName. The value passed via -ClassName will be ignored."
+         Write-Warning "Both -ClassName was specified and -Tokens, containing a value for ClassName. The value passed via -Tokens will be ignored."
+      }
+
+      if ($ClassName -eq $Namespace)
+      {
+         throw "ClassName cannot be equal to Namespace"
       }
       
       $currentDir = (Get-Location).Path

--- a/tests/BinWips.Tests.ps1
+++ b/tests/BinWips.Tests.ps1
@@ -240,6 +240,22 @@ Describe 'New-BinWips' {
         $csContent | Should -BeLike "*class MyClass*"
     }
 
+    It 'Given a custom class name and a Tokens parameter, should use the -ClassName' -Tag "CustomClassName", "ClassNameConflict" {
+        $sb = {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $true)]
+                [string]$foo
+            )
+            Write-Output "$foo"
+        }
+        New-BinWips -ScriptBlock $sb -ScratchDir $script:scratchDir -OutFile $script:outFile `
+                 -ClassName "MyClass" -Tokens @{ClassName="MyOtherClass"} -Verbose
+        $script:outFile | Should -Exist
+        $csContent = Get-Content $script:scratchDir/PSBinary.cs -Raw
+        $csContent | Should -BeLike "*class MyClass*"
+    }
+
     It 'Given a custom namespace, should use that namespace' -Tag "CustomNamespace" {
         $sb = {
             [CmdletBinding()]
@@ -253,6 +269,38 @@ Describe 'New-BinWips' {
         $script:outFile | Should -Exist
         $csContent = Get-Content $script:scratchDir/PSBinary.cs -Raw
         $csContent | Should -BeLike "*namespace MyNamespace*"
+    }
+
+    It 'Given a custom namespace and a Tokens parameter, should use the -Namespace' -Tag "CustomNamespace", "NamespaceConflict" {
+        $sb = {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $true)]
+                [string]$foo
+            )
+            Write-Output "$foo"
+        }
+        New-BinWips -ScriptBlock $sb -ScratchDir $script:scratchDir -OutFile $script:outFile `
+                 -Namespace "MyNamespace" -Tokens @{Namespace="MyOtherNamespace"} -Verbose
+        $script:outFile | Should -Exist
+        $csContent = Get-Content $script:scratchDir/PSBinary.cs -Raw
+        $csContent | Should -BeLike "*namespace MyNamespace*"
+    }
+
+
+    It 'Given a -ClassName and -Namespace that match, should throw' -Tag "CustomClassName", "CustomNamespace", "ErrorHandling" {
+        $sb = {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $true)]
+                [string]$foo
+            )
+            Write-Output "$foo"
+        }
+        { 
+            New-BinWips -ScriptBlock $sb -ScratchDir $script:scratchDir -OutFile $script:outFile `
+                 -Namespace "MyNamespace" -ClassName "MyNamespace" -Verbose
+        } | Should -Throw -ExpectedMessage "ClassName cannot be equal to Namespace"
     }
 
     It 'Given a custom class template, uses that template' -Tag "ClassTemplate" { 

--- a/tests/BinWips.Tests.ps1
+++ b/tests/BinWips.Tests.ps1
@@ -250,7 +250,7 @@ Describe 'New-BinWips' {
             Write-Output "$foo"
         }
         New-BinWips -ScriptBlock $sb -ScratchDir $script:scratchDir -OutFile $script:outFile `
-                 -ClassName "MyClass" -Tokens @{ClassName="MyOtherClass"} -Verbose
+                 -ClassName "MyClass" -Tokens @{ClassName="MyOtherClass"}
         $script:outFile | Should -Exist
         $csContent = Get-Content $script:scratchDir/PSBinary.cs -Raw
         $csContent | Should -BeLike "*class MyClass*"
@@ -281,7 +281,7 @@ Describe 'New-BinWips' {
             Write-Output "$foo"
         }
         New-BinWips -ScriptBlock $sb -ScratchDir $script:scratchDir -OutFile $script:outFile `
-                 -Namespace "MyNamespace" -Tokens @{Namespace="MyOtherNamespace"} -Verbose
+                 -Namespace "MyNamespace" -Tokens @{Namespace="MyOtherNamespace"} 
         $script:outFile | Should -Exist
         $csContent = Get-Content $script:scratchDir/PSBinary.cs -Raw
         $csContent | Should -BeLike "*namespace MyNamespace*"
@@ -299,7 +299,7 @@ Describe 'New-BinWips' {
         }
         { 
             New-BinWips -ScriptBlock $sb -ScratchDir $script:scratchDir -OutFile $script:outFile `
-                 -Namespace "MyNamespace" -ClassName "MyNamespace" -Verbose
+                 -Namespace "MyNamespace" -ClassName "MyNamespace"  
         } | Should -Throw -ExpectedMessage "ClassName cannot be equal to Namespace"
     }
 


### PR DESCRIPTION
Release 0.0.6-alpha

Fixes focused mainly on testing and documentation. 

- Fixed: Docs incorrectly state that tokens would override `-Namespace` and `-ClassName` parameters
- Added tests to ensure correct usage of `-Namespace` and `-ClassName` when used with `-Tokens`
- Updated ReadMe to have "true" docs for parameters instead of copy-pasta from get-help
- Added more checks in pipeline to ensure we don't publish bflat compiler
- Correctly check for Namespace ClassName conflicts